### PR TITLE
fix language filter for fairytale list

### DIFF
--- a/app/src/main/java/cz/movapp/app/ui/children/ChildrenFairyTalesAdapter.kt
+++ b/app/src/main/java/cz/movapp/app/ui/children/ChildrenFairyTalesAdapter.kt
@@ -27,7 +27,7 @@ class ChildrenFairyTalesAdapter(
     fun setSupportedDataset() {
         supportedDataset = dataset.filter {
             it.first.supportedLanguages.contains(langPair.from.langCode) &&
-            it.first.supportedLanguages.contains(langPair.from.langCode)
+            it.first.supportedLanguages.contains(langPair.to.langCode)
         }
     }
 


### PR DESCRIPTION
The language filter filtering fairytale list (based on supported languages ) filters in one direction.

This was obviously a copy-and-paste error because the same direction is present in the code twice.

This PR simply changes one direction to the opposite one.